### PR TITLE
add checker to prevent crashing syntax

### DIFF
--- a/src/director/parse_execute.c
+++ b/src/director/parse_execute.c
@@ -6,11 +6,55 @@
 /*   By: dlu <dlu@student.42berlin.de>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/26 18:00:35 by dlu               #+#    #+#             */
-/*   Updated: 2023/07/06 10:41:45 by dlu              ###   ########.fr       */
+/*   Updated: 2023/07/06 17:49:03 by dlu              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+#define ERR_PAREN	"parenthese only support priority next to logical operators"
+
+/* Check pipeline does not contain control structures. */
+static bool	pipe_check(t_cmd *cmd)
+{
+	t_cmd	*temp;
+
+	if (!cmd)
+		return (true);
+	if (cmd->type == COMMAND)
+	{
+		temp = cmd->pipe;
+		while (temp)
+		{
+			if (temp->type != COMMAND)
+				return (false);
+			temp = temp->pipe;
+		}
+	}
+	return (pipe_check(cmd->left) && pipe_check(cmd->right));
+}
+
+/* Check parentheses are only next to logical operators. */
+static bool	paren_check(t_token *t)
+{
+	while (t)
+	{
+		if (t->type == LPARENT || t->type == RPARENT)
+		{
+			if ((t->prev && t->prev->type != AND && t->prev->type != OR)
+				|| (t->next && t->next->type != AND && t->next->type != OR))
+				return (ft_perror(ERR_PAREN), false);
+		}
+		t = t->next;
+	}
+	return (true);
+}
+
+/* Check syntax is valid. */
+static bool	syntax_check(t_cmd *cmd, t_token *tok)
+{
+	return (pipe_check(cmd) && paren_check(tok));
+}
 
 /* Parse the entire cli then execute. */
 int	parse_execute(char *line)
@@ -21,7 +65,7 @@ int	parse_execute(char *line)
 	g_shell.tok = g_shell.tok_head;
 	g_shell.parse_error = false;
 	g_shell.ast = build_conditional();
-	if (!g_shell.parse_error)
+	if (!g_shell.parse_error && syntax_check(g_shell.ast, g_shell.tok_head))
 		executor(g_shell.ast);
 	else
 		ft_perror("parser error");

--- a/src/xecutor/pipex.c
+++ b/src/xecutor/pipex.c
@@ -6,7 +6,7 @@
 /*   By: mcutura <mcutura@student.42berlin.de>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/28 13:34:17 by mcutura           #+#    #+#             */
-/*   Updated: 2023/07/06 17:30:38 by dlu              ###   ########.fr       */
+/*   Updated: 2023/07/06 17:50:58 by dlu              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,7 +65,7 @@ static int	supermario(t_cmd *cmd, int i, int len, int fd[2][2])
 	if (!args[0] && invalid_command(cmd))
 		exit(EXIT_FAILURE);
 	if (execve(args[0], args, g_shell.envp) == -1)
-		return (EXIT_FAILURE);
+		exit(EXIT_FAILURE);
 	return (EXIT_FAILURE);
 }
 

--- a/src/xecutor/pipex.c
+++ b/src/xecutor/pipex.c
@@ -6,7 +6,7 @@
 /*   By: mcutura <mcutura@student.42berlin.de>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/28 13:34:17 by mcutura           #+#    #+#             */
-/*   Updated: 2023/07/06 10:48:03 by dlu              ###   ########.fr       */
+/*   Updated: 2023/07/06 17:30:38 by dlu              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,10 +84,9 @@ int	pipex(t_cmd *cmd)
 	i = -1;
 	while (++i < pipelen)
 	{
+		ft_wait(100000);
 		pids[i] = fork();
-		if (pids[i] < 0)
-			return (free(pids), EXIT_FAILURE);
-		if (!pids[i] && supermario(cmd, i, pipelen, fd))
+		if (pids[i] < 0 || (!pids[i] && supermario(cmd, i, pipelen, fd)))
 			return (free(pids), EXIT_FAILURE);
 		cmd = cmd->pipe;
 	}

--- a/src/xecutor/xecutor.c
+++ b/src/xecutor/xecutor.c
@@ -6,7 +6,7 @@
 /*   By: mcutura <mcutura@student.42berlin.de>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/18 01:36:26 by mcutura           #+#    #+#             */
-/*   Updated: 2023/07/06 10:49:19 by dlu              ###   ########.fr       */
+/*   Updated: 2023/07/06 17:28:08 by dlu              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ static int	simple(t_cmd *cmd)
 		if (!args[0] && invalid_command(cmd))
 			exit(EXIT_FAILURE);
 		if (execve(args[0], args, g_shell.envp) == -1)
-			return (EXIT_FAILURE);
+			exit(EXIT_FAILURE);
 	}
 	waitpid(pid, &status, 0);
 	if (WIFEXITED(status))
@@ -67,7 +67,6 @@ static int	or(t_cmd *cmd)
 /* Couldn't find the command, print error message. */
 int	invalid_command(t_cmd *cmd)
 {
-	ft_wait(100000);
 	ft_dprintf(STDERR_FILENO, "minishell: %s: command not found\n",
 		cmd->args[0]);
 	return (EXIT_FAILURE);


### PR DESCRIPTION
Last one for the day.. 

Simple syntax checker to prevent infinite loop or nonsensical syntax. 
And minor fixes: shorter lines for norm, wait at the right place, caught some more return that should have been exit. 
